### PR TITLE
Add `table.column.key.encode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Descrição de todos os parâmetros:
 | table.column.payload        | sim           | Nome da coluna que tem os dados da mensagem |
 | table.column.payload.encode | não           | Como o payload está encodado na tabela, opções possíveis são base64 (valor default) e byte_array) |
 | table.column.key            | sim           | Nome da coluna que tem a chave da mensagem. Não é a PK da tabela, é a chave que será usada como partition key no envio da mensagem |
+| table.column.key.encode     | não           | Se a key estiver encodada na tabela, opções possíveis são string (valor default), base64 e byte_array) |
 | table.column.topic          | não           | Nome da coluna que tem o nome do tópico que deve ser enviado a mensagem. Apesar de opcional, se não for informado, deve ser informado o parâmetro routing.topic |
 | routing.topic               | não           | Nome do tópico que deve ser encaminhado a mensagem, sobrescreve table.column.topic. Use se você tem várias tabelas de outbox ou vai filtrar os eventos de cada tópico via query |
 | table.column.headers        | não           | Nome das colunas, separadas por vírgula, para serem adicionadas ao header da mensagem  |
@@ -117,3 +118,21 @@ tópico do kafka. Exemplo
 
 A coluna do banco de dados deve ser do tipo numérica e convertida para um Integer (Int32).
 Quando o parâmetro não é informado, nenhum número de partição é informado para o kafka.
+
+### table.column.key.encode
+
+Quando a key está codificada (encodada) no banco de dados, é possível decodificada usando decodificação para base64, 
+byte_array ou o valor default que é string.
+
+```json
+{
+  "transforms": "outbox",
+  "transforms.outbox.table.column.key.encode": "base64"  
+}
+```
+
+Quando o parâmetro não é informado, assume-se o valor string, presumindo que o valor para a chave está codificada em 
+string.
+
+> **Importante** Se o valor no banco de dados é NULL, informamos uma key randômica (`UUID.randomUUID()`) para evitar 
+> qualquer problema com NPE no connector.

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = 'kconnect-outbox-smt'
-version = '0.0.4'
+version = '1.0.0'
 sourceCompatibility = 1.8
 
 dependencies {
@@ -20,8 +20,9 @@ dependencies {
 	implementation group: 'org.apache.kafka', name: 'connect-transforms', version: '2.7.0'
 	implementation group: 'io.confluent', name: 'kafka-connect-avro-converter', version: '5.2.1'
 
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }
 
 test {

--- a/src/main/java/transform/outbox/AvroJdbcOutboxFields.java
+++ b/src/main/java/transform/outbox/AvroJdbcOutboxFields.java
@@ -100,6 +100,16 @@ public class AvroJdbcOutboxFields {
 		ConfigDef.Width.SHORT, //
 		null);
 
+	static TransformField FIELD_KEY_ENCODE = new TransformField(9, //
+		"outbox.table", //
+		"table.column.key.encode", //
+		"message key encode", //
+		"The way how the key is encoded (valid values are base64, byte_array or string). Default value is string", //
+		ConfigDef.Type.STRING, //
+		ConfigDef.Importance.HIGH, //
+		ConfigDef.Width.MEDIUM, //
+		"string");
+
 	static final List<TransformField> ALL_FIELDS = Arrays.asList(AvroJdbcOutboxFields.FIELD_KEY_COLUMN, //
 			AvroJdbcOutboxFields.FIELD_PAYLOAD_COLUMN, //
 			AvroJdbcOutboxFields.FIELD_SCHEMA_REGISTRY, //
@@ -122,6 +132,10 @@ public class AvroJdbcOutboxFields {
 
 	public String getMessagePayloadEncodeField() {
 		return FIELD_PAYLOAD_ENCODE.getReqString(transformConfigMap);
+	}
+
+	public String getMessageKeyEncodeField() {
+		return FIELD_KEY_ENCODE.getReqString(transformConfigMap);
 	}
 
 	public String getMessageTopicField() {


### PR DESCRIPTION
Permite decode dos valores informados para key do evento. O novo parâmetro é o:

* `table.column.key.encode`.

Também, garante que a key nunca seja nula. Encontrei alguns comportamentos estranhos quando o valor lido do banco de dado para uma determinada key era null.