### PR TITLE
update the kafka-connect-converter lib to version 7.2.2 and tweak the…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,17 +12,22 @@ repositories {
 }
 
 group = 'kconnect-outbox-smt'
-version = '1.0.1'
+version = '1.0.2'
 sourceCompatibility = 1.8
 
 dependencies {
 	implementation group: 'org.apache.kafka', name: 'connect-api', version: '2.7.0'
 	implementation group: 'org.apache.kafka', name: 'connect-transforms', version: '2.7.0'
-	implementation group: 'io.confluent', name: 'kafka-connect-avro-converter', version: '5.2.1'
 
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
-	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+	implementation('io.confluent:kafka-connect-avro-converter:7.2.2') {
+		exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+	}
+
+	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0-rc3'
+
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }
 
 test {

--- a/src/main/java/transform/TransformField.java
+++ b/src/main/java/transform/TransformField.java
@@ -55,7 +55,7 @@ public class TransformField {
 	}
 
 	public int getReqInteger(Map<String, ?> transformConfigMap) {
-		return Integer.valueOf(getReqString(transformConfigMap));
+		return Integer.parseInt(getReqString(transformConfigMap));
 	}
 
 	public String getReqString(Map<String, ?> transformConfigMap) {

--- a/src/test/java/transform/outbox/LocalSampleRunTest.java
+++ b/src/test/java/transform/outbox/LocalSampleRunTest.java
@@ -2,6 +2,8 @@ package transform.outbox;
 
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.avro.AvroDataConfig;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -28,7 +30,10 @@ class LocalSampleRunTest {
         GenericContainerWithVersion aa = deserializer.deserialize("user.changed", false, b);
         System.out.println(aa.container());
         SchemaMetadata latestSchemaMetadata = schemaRegistryClient.getLatestSchemaMetadata("user.changed-value");
-        org.apache.avro.Schema schema = schemaRegistryClient.getById(latestSchemaMetadata.getId());
+
+        ParsedSchema schemaById = schemaRegistryClient.getSchemaById(latestSchemaMetadata.getId());
+        org.apache.avro.Schema schema = schemaById instanceof AvroSchema ? ((AvroSchema) schemaById).rawSchema() : null;
+
         GenericContainer rec = SpecificData.get().deepCopy(schema, aa.container());
 
         AvroDataConfig avroDataConfig = new AvroDataConfig.Builder().with("schemas.cache.config", 10).build();


### PR DESCRIPTION
… getById method that is deprecated; version upgrade of unit tests libs; solved by cve jackson with version 2.14; and line wrap for parseInt method in TransformField class