### PR TITLE
Fix partition value type casting

### DIFF
--- a/src/main/java/transform/outbox/AvroJdbcOutbox.java
+++ b/src/main/java/transform/outbox/AvroJdbcOutbox.java
@@ -261,13 +261,13 @@ public class AvroJdbcOutbox<R extends ConnectRecord<R>> implements Transformatio
 
 	private Integer getPartitionNumber(final Struct eventStruct) {
 		if (this.partitionField != null) {
-			final Object partitionValue = eventStruct.get(this.partitionField);
+			final String partitionValue = (String) eventStruct.get(this.partitionField);
 
 			if (partitionValue == null) {
 				return null;
 			}
 
-			return ((BigDecimal) partitionValue).intValue();
+			return Integer.parseInt(partitionValue);
 		}
 		return null;
 	}


### PR DESCRIPTION
The partition field is mapped as a String and is cast as a BigDecimal to get the integer value. The problem is that it's not possible to cast a String to a BigDecimal with usual type casting, this type of casting ends up throwing a ClassCastException.

BigDecimal is supposed to represent precision signed decimal numbers, but the partition is never going to be a decimal or unsigned number, so the casting was changed to parse directory to an integer.